### PR TITLE
Add validation rule to DebtRequest

### DIFF
--- a/app/Http/Requests/Tenant/DebtRequest.php
+++ b/app/Http/Requests/Tenant/DebtRequest.php
@@ -49,7 +49,8 @@ class DebtRequest extends FormRequest
             ],
             "amount_debt" => [
                 "required",
-                "numeric"
+                "numeric",
+                "gt:0"
             ],
             "note" => [
                 "max:500",
@@ -92,7 +93,8 @@ class DebtRequest extends FormRequest
             "exists" => "Dữ liệu không tồn tại!",
             "in" => "Giá trị không hợp lệ!",
             "unique" => "Dữ liệu đã tồn tại!",
-            "numeric" => "Chỉ được nhập số!"
+            "numeric" => "Chỉ được nhập số!",
+            "gt" => "Phải lớn hơn 0!",
         ];
     }
 }


### PR DESCRIPTION
This commit includes an additional validation rule in the DebtRequest file. It ensures that the "amount_debt" field is not only numeric but also greater than 0. Moreover, a related error message has been provided for this new condition to give the user clear feedback.