### PR TITLE
Remove "greater than 0" validation for quantity

### DIFF
--- a/app/Http/Requests/Tenant/VariationQuantityRequest.php
+++ b/app/Http/Requests/Tenant/VariationQuantityRequest.php
@@ -30,7 +30,6 @@ class VariationQuantityRequest extends FormRequest
             "quantity" => [
                 "required",
                 "numeric",
-                "gt:0",
                 "integer"
             ]
         ];


### PR DESCRIPTION
The "greater than 0" validation rule for the quantity field in the VariationQuantityRequest has been removed to allow zero quantity. This change aligns the validation with the use case where zero quantity is a valid input.